### PR TITLE
FIX: use docker instead of dockerhub and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ Please view the original README on the [al-folio github repo](https://github.com
 
   * [Getting started](#getting-started)
     + [Installation](#installation)
-      - [Local setup using Docker (Recommended on Windows)](#local-setup-using-docker-recommended-on-windows)
-      - [Local Setup (Standard)](#local-setup-standard)
+      - [Local setup using Docker (Recommended)](#local-setup-using-docker-recommended)
+      - [Local Setup (Legacy)](#local-setup-legacy)
       - [Deployment](#deployment)
-      - [Upgrading from a previous version](#upgrading-from-a-previous-version)
     + [FAQ](#faq)
   * [Features](#features)
     + [Publications](#publications)
@@ -69,7 +68,7 @@ For a hands-on walkthrough of al-folio installation, check out [this cool video 
 
 ---
 
-#### Local setup using Docker (Recommended on Windows)
+#### Local setup using Docker (Recommended)
 
 You need to take the following steps to get `al-folio` up and running in your local machine:
 
@@ -81,42 +80,20 @@ git clone git@github.com:<your-username>/<your-repo-name>.git
 cd <your-repo-name>
 ```
 
-Finally, run the following command that will pull a pre-built image from DockerHub and will run your website.
-
-```bash
-./bin/dockerhub_run.sh
-```
-
-Note that when you run it for the first time, it will download a docker image of size 300MB or so.
-
-Now, feel free to customize the theme however you like (don't forget to change the name!). After you are done, you can use the same command (`bin/dockerhub_run.sh`) to render the webpage with all you changes. Also, make sure to commit your final changes.
-
-<details><summary>(click to expand) <strong>Build your own docker image (more advanced):</strong></summary>
-
-> Note: this approach is only necessary if you would like to build an older or very custom version of al-folio.
-
-First, download the necessary modules and install them into a docker image called `al-folio:Dockerfile` (this command will build an image which is used to run your website afterwards. Note that you only need to do this step once. After you have the image, you no longer need to do this anymore):
-  
-
-```bash
-./bin/docker_build_image.sh  
-```
-
-Run the website!
+Finally, run the following command that will pull a pre-built image from Docker and will run your website.
 
 ```bash
 ./bin/docker_run.sh
 ```
 
-> To change port number, you can edit `docker_run.sh` file.
+Note that when you run it for the first time, it will download a docker image of size 300MB or so.
 
-> If you want to update jekyll, install new ruby packages, etc., all you have to do is build the image again using `docker_build_image.sh`! It will download ruby and jekyll and install all ruby packages again from scratch.
+Now, feel free to customize the theme however you like (don't forget to change the name!). After you are done, you can use the same command (`bin/docker_run.sh`) to render the webpage with all you changes. Also, make sure to commit your final changes. It's also possible to change port number by editing the `docker_run.sh` file.
 
-</details>
 
 ---
 
-#### Local Setup (Standard)
+#### Local Setup (Legacy)
 
 Assuming you have [Ruby](https://www.ruby-lang.org/en/downloads/) and [Bundler](https://bundler.io/) installed on your system (*hint: for ease of managing ruby gems, consider using [rbenv](https://github.com/rbenv/rbenv)*), first [fork](https://guides.github.com/activities/forking/) the theme from `github.com:alshedivat/al-folio` to `github.com:<your-username>/<your-repo-name>` and do the following:
 
@@ -212,24 +189,6 @@ In its default configuration, al-folio will copy the top-level `README.md` to th
 **Note:** Do _not_ run `jekyll clean` on your publishing source repo as this will result in the entire directory getting deleted, irrespective of the content of `keep_files` in `_config.yml`.
 
 </details>
-
----
-
-#### Upgrading from a previous version
-
-If you installed **al-folio** as described above, you can upgrade to the latest version as follows:
-
-```bash
-# Assuming the current directory is <your-repo-name>
-git remote add upstream https://github.com/alshedivat/al-folio.git
-git fetch upstream
-git rebase v0.3.5
-```
-
-If you have extensively customized a previous version, it might be trickier to upgrade.
-You can still follow the steps above, but `git rebase` may result in merge conflicts that must be resolved.
-See [git rebase manual](https://help.github.com/en/github/using-git/about-git-rebase) and how to [resolve conflicts](https://help.github.com/en/github/using-git/resolving-merge-conflicts-after-a-git-rebase) for more information.
-If rebasing is too complicated, we recommend to re-install the new version of the theme from scratch and port over your content and changes from the previous version manually.
 
 ---
 

--- a/bin/docker_build_image.sh
+++ b/bin/docker_build_image.sh
@@ -1,5 +1,0 @@
-  FILE=Gemfile.lock
-if [ -f "$FILE" ]; then
-    rm $FILE
-fi
-  docker build -t "al-folio:latest" . 

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -2,6 +2,7 @@ FILE=Gemfile.lock
 if [ -f "$FILE" ]; then
     rm $FILE
 fi
+docker build -t "al-folio:latest" . 
 docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
                     -it al-folio:latest bundler  \
                     exec jekyll serve --future --watch --port=8080 --host=0.0.0.0 

--- a/bin/dockerhub_run.sh
+++ b/bin/dockerhub_run.sh
@@ -1,7 +1,0 @@
-FILE=Gemfile.lock
-if [ -f "$FILE" ]; then
-    rm $FILE
-fi
-docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
-                    -it amirpourmand/al-folio bundler  \
-                    exec jekyll serve --future --watch --port=8080 --host=0.0.0.0 


### PR DESCRIPTION
I also removed the section "Upgrading from a previous version" because I don't think it's applicable to the blog post track (correct me if I'm wrong)