### PR TITLE
Smaller urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -114,7 +114,7 @@ bing_site_verification:  # out your bing-site-verification ID (Bing Webmaster)
 blog_name: blogposts # blog_name will be displayed in your blog page
 blog_nav_title: blog # your blog must have a title for it to be displayed in the nav bar
 blog_description: Blog Posts
-permalink: /blog/:year/:title/
+permalink: /blog/:title/
 
 # Pagination
 pagination:


### PR DESCRIPTION
I've noticed that blog posts have the year twice in the URL (e.g., `/2024/blog/2024/distill-example/`).

This removes the second 2024