### PR TITLE
Merge actions charlie

### DIFF
--- a/.github/workflows/filter-test-dev.yml
+++ b/.github/workflows/filter-test-dev.yml
@@ -1,0 +1,103 @@
+name: Filter Test Dev
+
+on:
+  pull_request:
+    types: [labeled]
+
+# hack for https://github.com/actions/cache/issues/810#issuecomment-1222550359
+#env:
+#  SEGMENT_DOWNLOAD_TIMEOUT_MIN: 3
+
+jobs:
+  files-changed:
+    name: Detect what files changed
+    if: contains(github.event.pull_request.labels.*.name, 'submission')  
+    # if: ${{ github.event.label.name == 'submission' }}
+    runs-on: ubuntu-20.04
+    timeout-minutes: 3
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        # Enable listing of files matching each filter.
+        # Paths to files will be available in `${FILTER_NAME}_files` output variable.
+        # Paths will be escaped and space-delimited.
+        # Output is usable as command-line argument list in Linux shell
+        list-files: shell
+    
+        # In this example changed files will be checked by linter.
+        # It doesn't make sense to lint deleted files.
+        # Therefore we specify we are only interested in added or modified files.
+        filters: |
+          changed:
+            - '**'
+    - name: Check label
+      run: echo ${{ github.event.label.name }}
+
+    - name: Check if changed files fit our filters
+      id: pythonfilter
+      if: ${{ steps.filter.outputs.changed == 'true' }}
+      # todo read from step below
+      run: python3 bin/filterpaths.py ${{ github.event.pull_request.title }} ${{ steps.filter.outputs.changed_files }}
+    - uses: actions/github-script@v6
+      if: always() && steps.pythonfilter.outcome == 'failure'
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Thanks for your submission! \n\nYou changed these files: ${{ steps.filter.outputs.changed_files }}.\n\nRecall that you can only add or modify files related to your post!\n\nPlease revert or remove the offending files back to their original version and re-submit :)'
+          })
+    - name: Setup Ruby
+      if: steps.pythonfilter.outcome == 'success'
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0.2'
+        bundler-cache: true
+    - name: Install deps
+      if: steps.pythonfilter.outcome == 'success'
+      run: |
+        npm install -g mermaid.cli
+    - name: Setup deploy options
+      if: steps.pythonfilter.outcome == 'success'
+      id: setup
+      run: |
+        git config --global user.name "GitHub Action"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        if [[ ${GITHUB_REF} = refs/pull/*/merge ]]; then # pull request
+          echo "SRC_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+          echo "NO_PUSH=--no-push" >> $GITHUB_OUTPUT
+        elif [[ ${GITHUB_REF} = refs/heads/* ]]; then # branch, e.g. master, source etc
+          echo "SRC_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        fi
+        echo "DEPLOY_BRANCH=gh-pages" >> $GITHUB_OUTPUT
+    - name: Deploy website 
+      if: steps.pythonfilter.outcome == 'success'
+      #if: steps.pythonfilter.outputs.exit_code == 0
+      run:  yes | bash bin/build --verbose ${{ steps.setup.outputs.NO_PUSH }}
+                    --src ${{ steps.setup.outputs.SRC_BRANCH }} 
+                    --deploy ${{ steps.setup.outputs.DEPLOY_BRANCH }} 
+                    --slug ${{ github.event.pull_request.title }}
+                    
+    - name: Use the Upload Artifact GitHub Action
+      if: steps.pythonfilter.outcome == 'success'
+     # if: steps.pythonfilter.outputs.exit_code == 0
+      uses: actions/upload-artifact@v2
+      with: 
+        name: website_out
+        path: site_out
+    - uses: actions/github-script@v6
+      if: steps.pythonfilter.outcome == 'success'
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '👋 Thanks for your submission! We have successfully built your website and we will push it shortly to the following URL! TODO'
+          })

--- a/.github/workflows/filter-test-dev.yml
+++ b/.github/workflows/filter-test-dev.yml
@@ -15,6 +15,8 @@ jobs:
     # if: ${{ github.event.label.name == 'submission' }}
     runs-on: ubuntu-20.04
     timeout-minutes: 3
+    outputs:
+      offendingfiles: ${{ steps.pythonfilter.outputs.offendingfiles }}
 
     steps:
     - name: Checkout code
@@ -42,7 +44,11 @@ jobs:
       id: pythonfilter
       if: ${{ steps.filter.outputs.changed == 'true' }}
       # todo read from step below
-      run: python3 bin/filterpaths.py ${{ github.event.pull_request.title }} ${{ steps.filter.outputs.changed_files }}
+      run: |
+        FILTEROUT=$(python3 bin/filterpaths.py ${{ github.event.pull_request.title }} ${{ steps.filter.outputs.changed_files }} | tail -1)
+        echo $FILTEROUT
+        echo "offendingfiles=$FILTEROUT" >> $GITHUB_OUTPUT
+        python3 bin/filterpaths.py ${{ github.event.pull_request.title }} ${{ steps.filter.outputs.changed_files }}
     - uses: actions/github-script@v6
       if: always() && steps.pythonfilter.outcome == 'failure'
       with:
@@ -51,7 +57,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: '👋 Thanks for your submission! \n\nYou changed these files: ${{ steps.filter.outputs.changed_files }}.\n\nRecall that you can only add or modify files related to your post!\n\nPlease revert or remove the offending files back to their original version and re-submit :)'
+            body: "👋 Thanks for your submission! \n\n${{ steps.pythonfilter.outputs.offendingfiles }}\n\nPlease make the aforementioned changes and re-submit :)"
           })
     - name: Setup Ruby
       if: steps.pythonfilter.outcome == 'success'

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Run this script to deploy the app to Github Pages
+
+# Parse cmd arguments
+
+SRC_BRANCH="master"
+DEPLOY_BRANCH="gh-pages"
+
+USAGE_MSG="usage: deploy [-h|--help] [-u|--user] [-s|--src SRC_BRANCH] [-d|--deploy DEPLOY_BRANCH] [--verbose] [--no-push]"
+
+while [[ $# > 0 ]]; do
+    key="$1"
+
+    case $key in
+        -h|--help)
+        echo $USAGE_MSG
+        exit 0
+        ;;
+        -u|--user)
+        SRC_BRANCH="source"
+        DEPLOY_BRANCH="master"
+        ;;
+        -s|--src)
+        SRC_BRANCH="$2"
+        shift
+        ;;
+        -g|--slug)
+        SLUG="$2"
+        shift
+        ;;
+        -d|--deploy)
+        DEPLOY_BRANCH="$2"
+        shift
+        ;;
+        --verbose)
+        set -x
+        ;;
+        --no-push)
+        NO_PUSH="--no-push"
+        ;;
+        *)
+        echo "Option $1 is unknown." >&2
+        echo $USAGE_MSG >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+# Exit if any subcommand fails
+set -e
+
+echo "Deploying..."
+echo "Source branch: $SRC_BRANCH"
+echo "Deploy branch: $DEPLOY_BRANCH"
+
+read -r -p "Do you want to proceed? [y/N] " response
+if [[ ! $response =~ ^([yY][eE][sS]|[yY])+$ ]]
+then
+    echo "Aborting."
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+fi
+
+# Check if there are any uncommitted changes
+if ! git diff-index --quiet HEAD --; then
+    echo "Changes to the following files are uncommitted:"
+    git diff-index --name-only HEAD --
+    echo "Please commit the changes before proceeding."
+    echo "Aborting."
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+fi
+
+# Check if there are any untracked files
+if ! test -z "$(git ls-files --exclude-standard --others)"; then
+    echo "There are untracked files:"
+    git ls-files --exclude-standard --others
+    echo "Please commit those files or stash them before proceeding."
+    echo "Aborting."
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1
+fi
+
+# Switch to source branch (creates it if necessary from the current branch)
+if [ `git branch | grep $SRC_BRANCH | tr ' ' '\n' | tail -1` ]
+then
+    git checkout $SRC_BRANCH
+else
+    git checkout -b $SRC_BRANCH
+fi
+
+# Checkout DEPLOY_BRANCH branch
+if [ `git branch | grep $DEPLOY_BRANCH` ]
+then
+  git branch -D $DEPLOY_BRANCH
+fi
+git checkout -b $DEPLOY_BRANCH
+
+# Export JEKYLL_ENV=production
+export JEKYLL_ENV=production
+
+# CHARLIE SEP 29 2023:
+# BEFORE BUILDING, WE NEED TO CHANGE THE _config.yaml URL, OTHERWISE THE WEBSITE URLS ARE ALL WRONG
+echo $SLUG
+python -c 'import yaml;f=open("_config.yml");y=yaml.safe_load(f);y["url"] = ""; outfile=open("_config.yml", "w"); yaml.dump(y, outfile, default_flow_style=False, sort_keys=False)'
+PASS_SLUG=$SLUG python -c 'import yaml; import os; f=open("_config.yml");y=yaml.safe_load(f);y["baseurl"] = os.environ["PASS_SLUG"]; outfile=open("_config.yml", "w"); yaml.dump(y, outfile, default_flow_style=False, sort_keys=False)'
+
+cat _config.yml
+
+# Build site
+bundle exec jekyll build --future
+
+# Delete and move files
+find . -maxdepth 1 ! -name '_site' ! -name '.git' ! -name 'CNAME' ! -name '.gitignore' -exec rm -rf {} \;
+zip -r site.zip _site/
+mkdir site_out
+mv site.zip site_out/
+exit 0

--- a/bin/filterpaths.py
+++ b/bin/filterpaths.py
@@ -7,6 +7,8 @@ SUCCESS = True
 
 SLUG = sys.argv[1]
 
+OUTPUT_MSG = ""
+
 SLUG_TEMPLATE = "2024-\d\d-\d\d-.+"
 if re.match(SLUG_TEMPLATE, SLUG) is None:
     print("Your slug does not match the template! Please change it.")
@@ -14,6 +16,7 @@ if re.match(SLUG_TEMPLATE, SLUG) is None:
     print(f"The template: {SLUG_TEMPLATE}")
     print("PATHFILTERFAILED")
     SUCCESS = False
+    OUTPUT_MSG = f"Your PR title does not match the slug template, which is <{SLUG_TEMPLATE}>."
 
 CHANGED_FILES = sys.argv[2:]
 ACCEPTABLE_PATHS = [
@@ -42,6 +45,17 @@ if len(failed_paths) > 0:
 else:
     print("PATHFILTERSUCCESS")
     SUCCESS = True
+
+if len(failed_paths) > 0:
+    if OUTPUT_MSG != "":
+        OUTPUT_MSG += " Also, y"
+    else:
+        OUTPUT_MSG = "Y"
+    
+    OUTPUT_MSG += f"ou can only add/change/remove files related to your post, i.e. files that match one of these patterns: <_posts/SLUG.md, assets/img/SLUG/..., assets/html/SLUG/..., assets/bibliography/SLUG.bib>. But we found that you changed the following: <{' & '.join(failed_paths)}>"
+if not SUCCESS:
+    OUTPUT_MSG += " Also, make sure your PR's title matches your post's slug!"
+    print(OUTPUT_MSG)
 
 # example usage of this script:  python3 filter_file.py 2024-0a1-01-whateve _posts/2024-01-01-whateve.md assets/img/2024-01-01-whateve/bla.pic assets/html/2024-01-01-whateve/plot1.j assets/bibliography/2024-01-01-whateve.bib assets/img/2024-01-02-whateve/bla.pic
 if SUCCESS:

--- a/bin/filterpaths.py
+++ b/bin/filterpaths.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+
+SUCCESS = True
+
+SLUG = sys.argv[1]
+
+SLUG_TEMPLATE = "2024-\d\d-\d\d-.+"
+if re.match(SLUG_TEMPLATE, SLUG) is None:
+    print("Your slug does not match the template! Please change it.")
+    print(f"Your slug: {SLUG}")
+    print(f"The template: {SLUG_TEMPLATE}")
+    print("PATHFILTERFAILED")
+    SUCCESS = False
+
+CHANGED_FILES = sys.argv[2:]
+ACCEPTABLE_PATHS = [
+    f"_posts/{SLUG}.md",
+    f"assets/img/{SLUG}/*",
+    f"assets/html/{SLUG}/*",
+    f"assets/bibliography/{SLUG}.bib"
+]
+
+failed_paths = []
+
+for changed_file in CHANGED_FILES:
+    for acc_path in ACCEPTABLE_PATHS:
+        if re.match(acc_path, changed_file) is not None:
+            break
+    else:
+        failed_paths.append(changed_file)
+
+if len(failed_paths) > 0:
+    print(f"These files were changed, but they shouldn't have been:")
+    for failed in failed_paths:
+        print(f"\t{failed}")
+
+    print("PATHFILTERFAILED")
+    SUCCESS = False
+else:
+    print("PATHFILTERSUCCESS")
+    SUCCESS = True
+
+# example usage of this script:  python3 filter_file.py 2024-0a1-01-whateve _posts/2024-01-01-whateve.md assets/img/2024-01-01-whateve/bla.pic assets/html/2024-01-01-whateve/plot1.j assets/bibliography/2024-01-01-whateve.bib assets/img/2024-01-02-whateve/bla.pic
+if SUCCESS:
+    exit(0)
+else:
+    exit(1)


### PR DESCRIPTION
**Merge-in of Github Action to handle file filtering and building the website archive**

This:
- Grabs PR's marked with ``submission'' label
- Runs regex filters on every modified/added/removed files. This file is in `bin/filterpaths.py'
- If filters fail, writes a comment on the PR. TODO: make comment say exactly which files are offending. Interrupts the action's flow and marks the PR with a red X to indicate a failure mode.
- If filters succeed, downloads the submission's code, builds it (`bin/build'), and uploads it to the github action's artefacts.
- TODO: push the artefact to AWS/some other server. Marks the PR with a green checkmark to indicate a successful submission.

Recap of TODOs:
1. Prevent the default Al_folio from deploying the website upon PRs
2. Extract offending file information from `filterpaths.py' and push it to the comment
3. Push website archive to AWS/some other server

