### PR TITLE
Create getting-to-the-bottom-of-the-philosophical-underpinning-of-ml-…

### DIFF
--- a/_posts/getting-to-the-bottom-of-the-philosophical-underpinning-of-ml-fairness-literature.md
+++ b/_posts/getting-to-the-bottom-of-the-philosophical-underpinning-of-ml-fairness-literature.md
@@ -1,0 +1,148 @@
+---
+
+layout: distill
+title: Sample Blog Post
+description: Corbett-Davies et al. outline neatly the existing approaches to ML fairness and propose a utlity-maximization alternative. I argue that every approach is flawed, and that a reflective equilibrium, incorporating approaches Crobett-Davies et al. argue against, might be a good alternative.
+date: 2023-12-17
+future: true
+htmlwidgets: true
+---
+> Socrates: You say that the capacity to get good things is virtue?
+> 
+> Meno: I do.
+> 
+> Socrates: And by good things you mean, for example, health and wealth?
+> 
+> Meno: I also mean amassing plenty of gold and silver—and winning honors and public office.
+> 
+> Socrates: So, by ‘good things’ you don’t mean other sorts of things than these?
+> 
+> Meno: No, I mean all things of this kind. 
+>
+>Socrates: Very well. According to Meno—hereditary guest friend of the Great King—virtue is getting your hands on the cash. Do you qualify this definition, Meno, with the words ‘justly’ and ‘piously’? Or is it all the same to you—virtue either way—if you make your fortune unjustly?
+> 
+> Meno: Certainly not, Socrates.
+> 
+> Socrates: You would call it viciousness, then?
+> 
+> Meno: That I would.
+> 
+> Socrates: It seems, then, that the getting of gold must go along with justice or moderation or piety or some other element of virtue. If it does not, it won’t be virtue, no matter what good things are obtained.
+> 
+> Meno: Yes. How could there be virtue if these elements were missing?
+> 
+> Socrates: Then failing to acquire gold and silver, whether for oneself or for another, if these other elements were missing from the situation, would be a case of virtue?
+> 
+> Meno: So it seems.
+> 
+> Socrates: It follows that getting hold of the goods will not be virtue any more so than failing to do so is. Apparently it’s the case that whatever is done with justice will be virtue, and whatever is done in the absence of these good qualities will be vice.
+> 
+> Plato's *Meno* translated by Belle Waring. Free pdf from the translator: <https://examinedlife.typepad.com/files/randpchapter8-1.pdf>
+
+
+
+# Getting to the bottom of the philosophical underpinning of ML Fairness literature
+
+
+In Plato's celebrated [*Meno*](https://en.wikipedia.org/wiki/Meno) [2], after the title character Meno asks Socrates whether virtue can be taught, he is taken on a whirlwind tour of the intellectual concepts, only to be brought by Socrates to the conclusion that virtue is (1) a gift from the gods (2) a concept that neither Meno nor Socrates really understand.
+
+Having armed myself with a generous helping of hubris and Corbett-Davies et al.'s excellent *JMLR* article "The Measure and Mismeasure of Fairness" [1], I would like to take you on a similar tour.
+
+I'll depart from the usual mid-2010s story -- the difficulty with understanding fairness in ML cannot be reduced to figuring out what your principles are and then mapping those  [3]. I'll also depart from the story by Corbett-Davies et al. -- it's not all about designing policies maximizing utility, however broadly utility is defined.
+
+Instead, I'll argue for a sort of reflective equilibrium: **ethical reasoning about any particular case needs to consider counterarguments, and, in particular, any principle that's articulated should be tested against challenging counterexamples -- a little Socrates whispering in your ear.**
+
+## All observational fairness measures are wrong
+
+Observational measures of fairness -- measures that you can get from a labelled dataset -- came to prominence in ML in the context of the [ProPublica COMPAS story](https://www.propublica.org/article/machine-bias-risk-assessments-in-criminal-sentencing) in 2016.
+
+The investigation revealed that the false-positive rate of the recidivism prediction COMPAS for African-American defendants was much higher than the false-positive rate for Caucasian defendants -- a larger percentage of African-American defendants who did not up being re-arrested were predicted to be re-arrested.
+
+### False-positive parity
+
+It was quickly pointed out that, if the base rates -- the percentage of people who are arrested -- differ by demographic, you can only have one but not more than one measure of fairness hold at a time.
+
+#### An intuitive explanation: a machine that can tell if you're 80% likely to be re-arrested
+
+Here's a shot at an intuitive explanation: suppose that, in the two groups A and B, you have people likely to be re-arrested and people not likely to be re-arrested, and the proportions in the two groups differ (something like that --but more complicated -- has to hold if the base-rates of arrest are different and arrests are not just based on the demographic and are otherwise random; while policing of different racial groups in the US is undoubtedly different, not all of it is due to race; for one thing, African-Americans are substantially younger, leading to more arrests: old people don't have what it takes for the kind of crime that gets you arrested).
+
+Suppose the system can perfectly discern whether an individual is in the set that's likely to be re-arrested R (defined, say, as the set of all people whose probability of re-arrest is 80%) or in the set that's not likely to be re-arrested, and that's *all* a system can do.
+
+If a recidivism prediction system perfectly discerns whether you're in the group that's likely to be re-arrested or not, if group A has more people who are likely to be re-arrested, it will also have more people labelled as likely to be re-arrested but who happen to not be -- not everyone likely to be re-arrested ends up being re-arrested.
+
+### Calibration
+
+But if the best you can do is tell if someone is in the subset that's likely to be re-arrested or not, it's difficult to argue against fudging the output and *not* doing that for the sake of achieving parity in the false-positive rates.
+
+In fact, under our hypothetical, the only way to accomplish this would be to first discern whether the person is likely or not likely to be re-arrested, and to then *arbitrarily flip the prediction* for a subset of one of the demographic groups.
+
+Following the assignment by the perfect predictor of likely re-arrest is using classifier that satisfies *calibration*: where the output (with some error) tries as well as possible to say 1 if the probability of 1 is above, say, 80%, and 0 otherwise.
+
+
+### A conflict of intuitions
+Under the artificial scenario I just described, it's difficult to argue for non-calibrated classifiers.
+
+And yet, many people (including myself) feel the pull of the argument that disparate false-positive rates indicate a problem.
+
+Here is one explanation: we implicitly reject the whole framework. Maybe the re-arrest patterns are biased in some way. Maybe predicting re-arrests is the wrong framework altogether -- maybe we care about actually-committed violent crime, and that's substantially different, if unknowable.
+
+### Intermezzo: all observational fairness measures are wrong, and all are useful
+
+[I would argue for this](https://en.wikipedia.org/wiki/All_models_are_wrong). One can argue against any fairness metric (as we have done above -- false-positive parity is bad because it's not consistent with calibration, calibration is bad because it doesn't account for model error and so leads to false-positive disparity), and that's because none of them are right.
+
+## Causal Fairness to the rescue?
+One possible way to resolve this is to say that the problem is that the measures are *observational*: what we really should care about is that a person with demographic A should be the same as that same person whose demographic had been, counterfactually, something else.
+
+As Corbett-Davies et al. point out, that is mostly unworkable. The demographics we care about here are deeply embedded in our social context. Someone whose demopgrahic had been different would have had very different life experience (that is *why* we care about disparities along demographics), making them a different person.
+
+(Note: this is different from "fairness through unawareness", or "color-blindness" in the context of race: counterfactual fairness requires thinking about the person's characteristics if they counterfactually *had been* a different demographic and had the corresponding life experience).
+
+If nothing else, this is a philosophical morass: what does it even mean to think of oneself as counterfactually being a different race or gender than you actually are? Political scientists Maya Sen and Omar Wasow [offered the beginning of a framework](https://www.annualreviews.org/doi/abs/10.1146/annurev-polisci-032015-010015) in a 2016 Annual Review of Political Science article [4], but applying this to ML fairness is highly nontrivial.
+
+Because of these difficulties, attempting to apply the counterfactual fairness criterion results in requiring demographic parity (i.e., the same proportion of "yes"es for everyone). Perhaps that's fine, but if that's what you want, you should just ask for it.
+
+Interestingly, in a recent paper, Anthis and Veitch point out that *sometimes* one could argue that [group fairness is really does correspond to counterfacutal fairness when robustness is required ](https://openreview.net/pdf?id=AmwgBjXqc3) [5].
+
+
+## Still stuck
+
+So we're stuck with the intuitively appealing notion of counterfactual fairness, which, if we try to approximate it, reduces to observational group fairness anyway, and observational measures that are all individually and collectively unappealing.
+
+## Just maximize utility instead?
+
+Corbett-Davies et al. offer a way out: set out whatever goals you want, and figure out a policy that gets you somewhere where everybody is better off.
+
+Corbett-Davies's and Sharad Goel's results here and elsewhere indicate that doing this reduces what economists call "deadweight loss": you can make everyone better off, and achieve goals such as diversity (in the case of college admission) better if you just directly aim for that instead of measuring fairness.
+
+### Same objection as before
+
+Are you maximizing the right goal? Did you compute the utility correctly?
+
+All those questions, to my mind, pull us again in the direction of simple group fairness.
+
+## Useful counterexamples
+
+One of the strengths of Corbett-Davies et al.'s paper is the [intuition pumps](https://en.wikipedia.org/wiki/Intuition_pump) they provide: when screening for disease and trying to save people's lives, do we *really* care about group fairness, or do we just want to save as many lives as possible? If a college's  admission policy doesn't satisfy an abstract criterion of fairness but makes everyone better off and increases diversity, is that bad?
+
+## A reflective equilibrium
+
+I don't think the intuition pumps should be discarded, and I think the fact that all measures of fairness are imperfect is an important one.
+
+I would argue for simply keeping all of those things in mind.
+
+Perhaps, as many authors argue, we are aiming for a (to my mind, somewhat incoherent) notion of counterfactual fairness (that also cannot be achieved), and are also trying for a pareto-optimal policy, which we cannot perfectly design.
+
+This would argue for looking at the shadows -- the projections, one might say -- of the ideal forms of all those on the real world, and taking account of all of them.
+
+This might be seen as an argument for something like a ["reflective equilibrium"](https://plato.stanford.edu/entries/reflective-equilibrium/), where we take all considerations into account while recognizing that none of them are perfectly coherent, and some are not consistent.
+
+
+[1] Sam Corbett-Davies, Johann D. Gaebler, Hamed Nilforoshan, Ravi Shroff, Sharad Goel "The Measure and Mismeasure of Fairness," *JMLR* 24(312):1−117, 2023.
+
+[2] I recommend Belle Waring's modern translation with John Holbo's excellent commentary, available online for free at https://www.reasonandpersuasion.com/ (On dead tree: [Reason and Persuasion: Three Dialogues by Plato with commentary and illustrations by John Holbo and translations by Belle Waring](https://www.amazon.com/gp/product/1522907521/ref=as_li_tl?ie=UTF8&camp=1789&creative=390957&creativeASIN=1522907521&linkCode=as2&tag=johnbellhavea-20&linkId=35E3JKRZS4MWQAOV))
+
+[3] I am sure *you*, the reader, didn't think of it that way. But certainly tens of thousands of undergraduates were taught that way, with perhaps a disclaimer attached saying that a more holistic approach could be better.
+
+[4] Maya Sen and Omar Wasow. "Race as a bundle of sticks: Designs that estimate effects of seemingly immutable characteristics." Annual Review of Political Science 19 (2016): 499-522.
+
+[5] Jacy Reese Anthis and Victor Veitch. "Causal Context Connects Counterfactual Fairness to Robust Prediction and Group Fairness." Proc. NeurIPS, 2023.


### PR DESCRIPTION
…fairness-literature.md

<!-- Please make sure you are opening a pull request against the `main` branch of the 2024 repo -->
<!-- Ensure that your title is the raw filename of your blog post markdown/html file -->

## OpenReview Submission Thread

<!-- link to your OpenReview submission -->

## Checklist before opening a PR

- [x] I am opening a pull request against the `main` branch of the `2024` repo.
- [x] The title of my PR is exactly the name of my markdown file
    - i.e. `_posts/2024-05-07-[SUBMISSION NAME].md` would require a PR name `2024-05-07-[SUBMISSION NAME]` 
- [x] I have **anonymized** my post: my author's list is `Anonymous`, and there is no potential
    content which can reveal my/my collaborators identities.
- [x] My post matches the formatting requirements, including (but not limited to):
    - [x] I have **ONLY MODIFIED** files in the following locations (failure to do so will result in 
        your PR automatically being closed!):
        - a Markdown (or HTML) file in `_posts/` with the format `_posts/2024-05-07-[SUBMISSION NAME].md` (or `.html`)
        - static image assets added to `assets/img/2024-05-07-[SUBMISSION NAME]/`
        - interactive HTML figures added  to `assets/html/2024-05-07-[SUBMISSION NAME]/`
        - citations in a bibtex file in `assets/bibliography/2024-05-07-[SUBMISSION NAME].bib`
    - [x] I have a short 2-3 sentence abstract in the `description` field of my front-matter ([example](https://github.com/iclr-blogposts/2024/blob/295ab5b4c31f2c7d421a4caf41e5481cbb4ad42c/_posts/2024-05-07-distill-example.md?plain=1#L4-L6))
    - [x] I have a table of contents, formatted using the `toc` field of my front-matter ([example](https://github.com/iclr-blogposts/2024/blob/295ab5b4c31f2c7d421a4caf41e5481cbb4ad42c/_posts/2024-05-07-distill-example.md?plain=1#L36-L47))
    - [x] My bibliography is correctly formatted, using a `.bibtex` file as per the sample post

## Any other comments
