### PR TITLE
2024-05-07-dpi-fsvi

### DIFF
--- a/_posts/2024-05-07-dpi-fsvi.md
+++ b/_posts/2024-05-07-dpi-fsvi.md
@@ -2,7 +2,7 @@
 layout: distill
 title: "Bridging the Data Processing Inequality and Function-Space Variational Inference"
 description: >-
-  This blog post explores the interplay between the <i>Data Processing Inequality (DPI)</i>, a cornerstone concept in information theory, and <i>Function-Space Variational Inference (FSVI)</i> within the context of Bayesian deep learning. The DPI governs the transformation and flow of information through stochastic processes, and its unique connection to FSVI is employed to highlight FSVI's focus on Bayesian predictive posteriors over parameter space. Throughout the post, theoretical concepts are intertwined with intuitive explanations and mathematical rigor, offering a comprehensive understanding of these complex topics. The post concludes by bringing together various ideas to explain why the choice of predictive priors (initial probability distributions assumed for model predictions before training) is important for training machine learning models and preventing overfitting. It also discusses the practical implications of these concepts in areas such as continual learning and knowledge distillation. By examining these concepts in depth, the post provides valuable insights for both theory and practice in machine learning, making it an informative resource for researchers and practitioners.
+  This blog post explores the interplay between the <i>Data Processing Inequality (DPI)</i>, a cornerstone concept in information theory, and <i>Function-Space Variational Inference (FSVI)</i> within the context of Bayesian deep learning. The DPI governs the transformation and flow of information through stochastic processes, and its unique connection to FSVI is employed to highlight FSVI's focus on Bayesian predictive posteriors over parameter space. The post examines various forms of the DPI, including the KL divergence based DPI, and provides intuitive examples and detailed proofs. It also explores the equality case of the DPI to gain a deeper understanding. The connection between DPI and FSVI is then established, showing how FSVI can measure a predictive divergence independent of parameter symmetries. The post relates FSVI to knowledge distillation and label entropy regularization, highlighting the practical relevance of the theoretical concepts. Throughout the post, theoretical concepts are intertwined with intuitive explanations and mathematical rigor, offering a comprehensive understanding of these complex topics. By examining these concepts in depth, the post provides valuable insights for both theory and practice in machine learning.
 date: 2024-05-07
 future: true
 htmlwidgets: true
@@ -54,6 +54,7 @@ toc:
       - name: "Consistency"
       - name: "Equality & Symmetries"
       - name: "Predictive Prior"
+      - name: "The FSVI Objective"
   - name: "Parameter Priors vs. Predictive Priors"
     subsections:
       - name: "Label Entropy Regularization"
@@ -245,10 +246,11 @@ The data processing inequality examines how information cannot increase due to p
 
 Concretely, this KL DPI states that processing data stochastically can only reduce information. More formally:
 
-<aside class="l-body box-note" markdown="1">
+<aside class="l-body box-important" markdown="1">
 Consider two distributions $$\qof{\W}$$ and $$\pof{\W}$$ over a random variable $$\W$$. Let $$Y = \fof{\W}$$ be a stochastic mapping from $$\W$$ to $$Y$$---that is, we could imagine having a noise random variable $$\boldsymbol{Z}$$ as a hidden input to $$\fof{\W}$$, i.e. $$\fof{\W;\boldsymbol{Z}}$$. Then the DPI states:
 
 $$\Kale{\qof{\W}}{\pof{\W}} \ge \Kale{\qof{Y}}{\pof{Y}}.$$
+
 </aside>
 
 That is, the KL divergence between $$\qof{Y}$$ and $$\pof{Y}$$ cannot be larger than the one between the original $$\qof{\W}$$ and $$\pof{\W}$$. Intuitively, the stochastic mapping $$\opf$$ induces a bottleneck that reduces how well we can distinguish between $$\opp$$ and $$\opq$$. Finally we have equality when $$\Kale{\qof{\W \given Y}}{\pof{\W \given Y}} = 0$$.
@@ -266,17 +268,25 @@ Generally, *variational inference* is a powerful technique for approximating com
 However, especially for deep neural networks, obtaining a good approximation of the parameter space can be difficult. One reason is the sheer size of the parameter space. Additionally, the parameterization of a neural network often contains many symmetries---different parameter configurations can lead to the same predictions of the model---that are not taken into account either. 
 
 Here, **Function-space variational inference (FSVI)** side-steps some of these restrictions by only requiring that the variational distribution matches the *Bayesian **predictive** posterior*:
-Whereas regular variational inference regularizes towards a parameter prior, FSVI regularizes towards a data prior. This is especially useful when the parameter prior is not very meaningful, e.g. an isotropic Gaussian prior, which is often used in Bayesian neural networks.
 
-<aside class="l-body box-note" markdown="1">
-In function-space variational inference, we regularize towards a data prior:
+If we define equivalence classes of model parameters according to the model predictions, FSVI aims to approximate the posterior distribution over *equivalence classes* of parameters $$\pof{[\w] \given \Dany}$$ rather than the posterior over raw parameters $$\pof{\w \given \Dany}$$. This is because $$\pof{[\w] \given \Dany}$$ captures the meaningful aspects of the posterior, as it is invariant to the symmetries and equivalences in the parameter space that leave the likelihood unchanged.
+
+To achieve this, FSVI employs an implicit variational distribution $$\qof{[\w]}$$ and minimizes an objective that is equivalent to regular variational inference on the equivalence classes $$\Kale{\qof{[\W]}}{\pof{[\W] \given \Dany}}$$. 
+
+By using an implicit variational distribution and leveraging the DPI, FSVI sidesteps the need to explicitly define the equivalence classes or specify a model that operates on them directly. Instead, FSVI relies on the fact that matching the predictive prior distributions in the limit of infinite data is sufficient to match the posteriors over equivalence classes overall. This leads to approximations we can connect to label entropy regularization and knowledge distillation.
+
+<aside class="l-body box-important" markdown="1">
+Function-space variational inference (FSVI) is a principled approach to Bayesian inference that respects the inherent symmetries and equivalences in overparameterized models. It focuses on approximating the meaningful posterior $$\pof{[\w] \given \Dany}$$ while avoiding the complexities of explicitly constructing and working with equivalence classes.
+The FSVI-ELBO regularizes towards a data prior:
 
 $$
 \begin{aligned}
 \E{\qof{\w}}{-\log \pof{\Dany \given \w}} + \Kale{\qof{\Y... \given \x...}}{\pof{\Y... \given \x...}},
 \end{aligned}
 $$
-unlike in regular variational inference, where we regularize towards a parameter prior: $$\Kale{\qof{\W}}{\pof{\W}}$$.
+
+unlike in regular variational inference, where we regularize towards a parameter prior $$\Kale{\qof{\W}}{\pof{\W}}$$.
+
 </aside>
 
 ## Background: Information-Theoretic Notation
@@ -1078,14 +1088,15 @@ The same holds for $$\opq$$.
 <aside class="l-body box-important" markdown="1">
 This commutative property is not unique to the equivalence class mapping but rather a general characteristic of applying functions to random variables. The mapping $$[\cdot]$$ transforms the random variable $$\W$$ into a new random variable $$[\W]$$, and remarkably, this transformation commutes with Bayesian inference.
 
-The proof above holds for any function $$\fof{\cdot}$$ applied to a random variable. We have the freedom to either draw a parameter sample from the posterior and then apply the function to it, or alternatively, perform Bayesian inference directly on the transformed random variable.
+The proof above holds for any function $$\fof{\cdot}$$ applied to a random variable. We are free to either draw a parameter sample from the posterior and then apply the function to it, or alternatively, perform Bayesian inference directly on the transformed random variable.
 
 Consequently, we have:
 
 $$[\W \given \Dany] = [\W] \given \Dany.$$
 
-These simple results deserve careful appreciation to fully internalize them.
 </aside>
+
+These simple results deserve careful appreciation to fully internalize them.
 
 ### Equality & Symmetries
 
@@ -1207,7 +1218,7 @@ In my opinion, this is a great result. We have shown both that the predictive pr
 
 Let's appreciate one more thing: the predictive prior can consist of infinitely many data points and still converge to a finite value. 
 
-### The True FSVI Objective
+### The FSVI Objective
 
 The true objective of FSVI is to perform variational inference in the space of equivalence classes, approximating the posterior $$\pof{[\w] \given \Dany}$$ that captures the meaningful aspects of the model while being invariant to parameter symmetries. This perspective reveals FSVI as a powerful and principled framework for Bayesian inference in overparameterized models, providing both conceptual and practical advantages over standard variational inference in parameter space.
 
@@ -1287,9 +1298,11 @@ The main technical difference is that knowledge distillation is using the revers
 
 ## Conclusion
 
-In this blog post, we took a deep dive into the data processing inequality (DPI) and its surprisingly far-reaching implications for modern Bayesian deep learning. By carefully examining the assumptions, equality conditions, and chain rule of the DPI, we arrived at an intuitive understanding of why function-space variational inference (FSVI) can be such a powerful tool. The DPI perspective illuminates how FSVI side-steps issues with high-dimensional parameter spaces by focusing on matching Bayesian predictive posteriors.
+In this blog post, we took a deep dive into the data processing inequality (DPI) and its surprisingly far-reaching implications for modern Bayesian deep learning. By carefully examining the assumptions, equality conditions, and chain rule of the DPI, we arrived at an intuitive understanding of why function-space variational inference (FSVI) can be such a powerful tool. The DPI perspective shows how FSVI side-steps issues with high-dimensional parameter spaces by focusing on matching Bayesian predictive posteriors.
 
 Reasoning about parameter equivalence classes under the lens of the DPI, we saw how predictive KL divergences can capture meaningful differences between models while ignoring superficial discrepancies due to symmetries. This provides a fresh perspective on the advantages of predictive priors over standard parameter priors commonly used in Bayesian neural networks.
+
+A key insight that emerged is that FSVI's true objective is to perform variational inference in the space of predictive equivalence classes, approximating the posterior $$\pof{[\w] \given \Dany}$$ that captures the meaningful aspects of the model while being invariant to parameter symmetries. By employing an implicit variational distribution and leveraging the DPI, FSVI sidesteps the need to explicitly define equivalence classes, relying instead on the fact that matching predictive distributions is sufficient to match the posteriors over equivalence classes in the infinite data limit. This reveals FSVI as a principled and elegant approach to Bayesian inference in overparameterized models.
 
 While our treatment only scratched the surface of the full mathematical story, the intuitions we developed allowed us to re-derive key results from the literature and uncover deep connections between seemingly disparate methods like entropy regularization, continual learning, and knowledge distillation. The examples and proofs peppered throughout solidified the core concepts.
 
@@ -1297,5 +1310,5 @@ More than a bag of technical tricks, the DPI reveals itself to be a powerful con
 
 ---
 
-**Acknowledgements.** Many thanks to [Freddie Bickford Smith](https://fbickfordsmith.com/) for very helpful comments and feedback on this post and to [Tim Rudner](https://timrudner.com/) for additional pointers to relevant literature and feedback on the FSVI section in particular 🤗
+**Acknowledgements.** Many thanks to [Freddie Bickford Smith](https://fbickfordsmith.com/) for very helpful comments and feedback on this post and to [Tim Rudner](https://timrudner.com/) for additional pointers to relevant literature and feedback on the FSVI section in particular 🤗 GPT-4 and Claude 3 Opus were used for editing.
 

--- a/_posts/2024-05-07-dpi-fsvi.md
+++ b/_posts/2024-05-07-dpi-fsvi.md
@@ -11,21 +11,7 @@ authors:
   - name: Andreas Kirsch
     url: "https://www.blackhc.net"
     affiliations:
-      name: University of Oxford (Former Affiliation)
-
-# authors:
-#   - name: Albert Einstein
-#     url: "https://en.wikipedia.org/wiki/Albert_Einstein"
-#     affiliations:
-#       name: IAS, Princeton
-#   - name: Boris Podolsky
-#     url: "https://en.wikipedia.org/wiki/Boris_Podolsky"
-#     affiliations:
-#       name: IAS, Princeton
-#   - name: Nathan Rosen
-#     url: "https://en.wikipedia.org/wiki/Nathan_Rosen"
-#     affiliations:
-#       name: IAS, Princeton
+      name: University of Oxford<sup>&ndash;2023</sup>
 
 # must be the exact same name as your blogpost
 bibliography: 2024-05-07-dpi-fsvi.bib  
@@ -910,7 +896,7 @@ When we directly optimize the KL divergence on a finite input dataset, for examp
 
 This is of particular interest in continual learning, where the prior for the next task is chosen to be the posterior from the previous task. In this case, the functional ELBO can be used to approximate the posterior of the previous model while incorporating new data.
 
-For two great papers that are very readable and provide further insights, see "*Continual learning via sequential function-space variational inference*"<d-cite key="rudner2022continual"></d-cite> and "*Tractable function-space variational inference in Bayesian neural networks*"<d-cite key="rudner2022tractable"></d-cite>, both by Rudner et al. (2022).
+For two great papers that are very readable and provide further insights, see "*Continual Learning via Sequential Function-Space Variational Inference*"<d-cite key="rudner2022continual"></d-cite> and "*Tractable Function-Space Variational Inference in Bayesian Neural Networks*"<d-cite key="rudner2022tractable"></d-cite>, both by Rudner et al. (2022).
 
 ## Comparison to FSVI in the Literature
 
@@ -929,7 +915,7 @@ $$
 This follows that from applying the DPI twice, as the logits are functions of the weights and the weights are functions of the logits.
 </aside>
 
-In practice, both works by Rudner et al. (2022), linearize the logits<d-footnote>The logits are the final activations of the neural network before applying the softmax function (in multi-class classification). They are not to be confused with the pre-logits, e.g. embeddings before the final linear layer.</d-footnote> (similar to a Laplace approximation) and use the DPI to show (in their notation):
+In practice, Rudner et al. (2022) and its continual learning follow-up linearize the logits<d-footnote>The logits are the final activations of the neural network before applying the softmax function (in multi-class classification). They are not to be confused with the pre-logits, e.g. embeddings before the final linear layer.</d-footnote> (similar to a Laplace approximation) and use the DPI to show (in their notation):
 
 $$
 \mathbb{D}_{\mathrm{KL}}\left(q_{f(\cdot ; \boldsymbol{\Theta})} \| p_{f(\cdot ; \boldsymbol{\Theta})}\right) \leq \mathbb{D}_{\mathrm{KL}}\left(q_{\Theta} \| p_{\Theta}\right)
@@ -1090,9 +1076,15 @@ Given this consistency, we don't have to differentiate between $$\hat\opp$$ and 
 The same holds for $$\opq$$.
 
 <aside class="l-body box-important" markdown="1">
-This is not a special property of the equivalence class mapping but a general property of applying functions to random variables: $$[\cdot]$$ maps the random variable $$\W$$ to the transformed random variable $$[\W]$$, and this mapping commutes with Bayesian inference.
+This commutative property is not unique to the equivalence class mapping but rather a general characteristic of applying functions to random variables. The mapping $$[\cdot]$$ transforms the random variable $$\W$$ into a new random variable $$[\W]$$, and remarkably, this transformation commutes with Bayesian inference.
 
-Above proof is valid for any function $$\fof{\cdot}$$ applied to a random variable: we can either draw a parameter sample from the posterior and apply the function to it or perform Bayesian inference on the transformed random variable.
+The proof above holds for any function $$\fof{\cdot}$$ applied to a random variable. We have the freedom to either draw a parameter sample from the posterior and then apply the function to it, or alternatively, perform Bayesian inference directly on the transformed random variable.
+
+Consequently, we have:
+
+$$[\W \given \Dany] = [\W] \given \Dany.$$
+
+These simple results deserve careful appreciation to fully internalize them.
 </aside>
 
 ### Equality & Symmetries
@@ -1106,7 +1098,9 @@ $$
 And again: what does the gap between the two terms tell us? 
 
 <aside class="l-body box-error" markdown="1">
-Intuitively speaking, $$\Kale{\qof{[\W]}}{\pof{[\W]}}$$ captures the meaningful divergence between approximate and true distribution, while $$\Kale{\qof{\W}}{\pof{\W}}$$ includes any divergence due to parameter symmetries that has no effect on the predictions, now or later. The gap between the two terms tells us how much redundancy is captured by the parameter-based KL divergence.
+Intuitively speaking, $$\Kale{\qof{[\W]}}{\pof{[\W]}}$$ captures the meaningful divergence between approximate and true distribution of the predictions, while $$\Kale{\qof{\W}}{\pof{\W}}$$ also includes divergence due to parameter symmetries that have no effect on the predictions, now or later. 
+
+The gap between the two terms tells us how much redundancy is captured by the parameter-based KL divergence.
 </aside>
 
 Let's look at a few examples to get a better understanding of this.
@@ -1131,10 +1125,11 @@ Let's look at a few examples to get a better understanding of this.
 
   $$
   \begin{aligned}
-  \Kale{\qof{\W}}{\pof{\W}} &= \Kale{\qof{\W \given \W \in [K\,2\pi, (K+1)\,2\pi]}}{\pof{\W \given \W \in [K\,2\pi, (K+1)\,2\pi]}} \\
+  &\Kale{\qof{\W}}{\pof{\W}} \\
+  &\quad= \Kale{\qof{\W \given \W \in [K\,2\pi, (K+1)\,2\pi]}}{\pof{\W \given \W \in [K\,2\pi, (K+1)\,2\pi]}} \\
   &\quad + \Kale{\qof{\W \in [K\,2\pi, (K+1)\,2\pi]}}{\pof{\W \in [K\,2\pi, (K+1)\,2\pi]}} \\
-  &= \Kale{\qof{[\W]}}{\pof{[\W]}} \\
-  &\quad + \Kale{\qof{\W \in [K\,2\pi, (K+1)\,2\pi]}}{\pof{\W \in [K\,2\pi, (K+1)\,2\pi]}}. 
+  &\quad= \Kale{\qof{[\W]}}{\pof{[\W]}} \\
+  &\quad\quad + \Kale{\qof{\W \in [K\,2\pi, (K+1)\,2\pi]}}{\pof{\W \in [K\,2\pi, (K+1)\,2\pi]}}. 
   \end{aligned}
   $$
 
@@ -1165,7 +1160,7 @@ This tells us that the predictive prior term can at best measure the KL divergen
 For the equality cases, we observe that:
 
 1. we need a 1:1 mapping between parameters and equivalence classes for the first bound to be tight, and
-2. we need $$\Kale{\qof{[\W] \given \Y_n,\x_n,...,\Y_1,\x_1}}{\pof{[\W] \given \Y_n,\x_n,...,\Y_1,\x_1}} \to 0$$ for $$n \to \infty$$ for the second bound to be tight.
+2. we need $$\Kale{\qof{[\W] \given \Y_n,\x_n,...,\Y_1,\x_1}}{\pof{[\W] \given \Y_n,\x_n,...,\Y_1,\x_1}} \to 0$$ for $$n \to \infty$$ for the second bound to be tight, following the deductions in the first part of this post.
 
 For **2.**: as we know from the chain rule that
 
@@ -1193,14 +1188,18 @@ $$
 \end{aligned}
 $$
 
-In other words, for a given $$[w']$$, in the space of equivalence classes as defined previously, the equivalence class of all MLE solutions in the data limit, $$[MLE]$$, will be unique by definition---the model is identifiable---and match $$[\w']$$<d-footnote>This follows from the consistency of MLE estimators but also from Berstein von Mises with a flat/uninformative prior.</d-footnote>. As the MLE is prior-independent once there is support for it, both $$\opq$$ and $$\opp$$ will converge to the MLE $$[\w']$$ with sufficient data. Taking the expectation, this yields $$\Kale{\qof{[\W]\given \Y,..., \x...}}{\pof{[\W] \given \Y,..., \x...}} \to 0$$ for $$n \to \infty$$, and thus, we have:
+In other words:
 
-$$
-\begin{aligned}
-& \Kale{\qof{[\W]}}{\pof{[\W]}} = \\
-&\quad = \sup_{n\in \mathbb{N}} \Kale{\qof{\Y_n,...,\Y_1\given\x_n,...,\x_1}}{\pof{\Y_n,...,\Y_1\given\x_n,...,\x_1}}.
-\end{aligned}
-$$
+1. For a given $$[w']$$, in the space of equivalence classes as defined previously, the equivalence class of all MLE solutions in the data limit, $$[MLE]$$, will be unique by definition---the model is identifiable---and match $$[\w']$$<d-footnote>This follows from the consistency of MLE estimators but also from Berstein von Mises with a flat/uninformative prior.</d-footnote>. 
+
+2. As the MLE is prior-independent once there is support for it, both $$\opq$$ and $$\opp$$ will converge to the MLE $$[\w']$$ with sufficient data. Taking the expectation, this yields $$\Kale{\qof{[\W]\given \Y,..., \x...}}{\pof{[\W] \given \Y,..., \x...}} \to 0$$ for $$n \to \infty$$, and thus, we have:
+
+  $$
+  \begin{aligned}
+  & \Kale{\qof{[\W]}}{\pof{[\W]}} = \\
+  &\quad = \sup_{n\in \mathbb{N}} \Kale{\qof{\Y_n,...,\Y_1\given\x_n,...,\x_1}}{\pof{\Y_n,...,\Y_1\given\x_n,...,\x_1}}.
+  \end{aligned}
+  $$
 
 (Again, this is not a formal proof but an intuition for why the gap might close in the data limit.)
 
@@ -1208,9 +1207,44 @@ In my opinion, this is a great result. We have shown both that the predictive pr
 
 Let's appreciate one more thing: the predictive prior can consist of infinitely many data points and still converge to a finite value. 
 
-## Parameter Priors vs. Predictive Priors
+### The True FSVI Objective
 
-What is the advantage of this all?
+The true objective of FSVI is to perform variational inference in the space of equivalence classes, approximating the posterior $$\pof{[\w] \given \Dany}$$ that captures the meaningful aspects of the model while being invariant to parameter symmetries. This perspective reveals FSVI as a powerful and principled framework for Bayesian inference in overparameterized models, providing both conceptual and practical advantages over standard variational inference in parameter space.
+
+<aside class="l-body box-important" markdown="1">
+FSVI aims to approximate the posterior distribution over *equivalence classes* of parameters $$\pof{[\w] \given \Dany}$$ rather than the posterior over raw parameters $$\pof{\w \given \Dany}$$.
+</aside>
+
+This is because $$\pof{[\w] \given \Dany}$$ captures the meaningful aspects of the posterior, as it is invariant to the symmetries and equivalences in the parameter space that leave the likelihood unchanged.
+
+To achieve this, FSVI employs an implicit variational distribution $$\qof{[\w]}$$ and minimizes the following objective, which is regular variational inference on the equivalence classes $$\Kale{\qof{[\W]}}{\pof{[\W] \given \Dany}}$$, decomposed using the insights discussed:
+
+$$
+\begin{aligned}
+&\Kale{\qof{[\W]}}{\pof{[\W] \given \Dany}} + \Hof{\Dany} \\
+&\quad = 
+\E{\qof{[\w]}}{-\log \pof{\Dany \given [\w]}} + \Kale{\qof{[\W]}}{\pof{[\W] \given \Dany}} \\
+&\quad = \E{\qof{\w}}{-\log \pof{\Dany \given \w}} + \Kale{\qof{[\W]}}{\pof{[\W] \given \Dany}} -  \Hof{\Dany} \\
+&\quad = \sup_n \E{\qof{\w}}{-\log \pof{\Dany \given \w}} + \Kale{\qof{\Y_n... \given \x_n...}}{\pof{\Y_n... \given \x_n...}} \\
+&\quad \ge \E{\qof{\w}}{-\log \pof{\Dany \given \w}} + \Kale{\qof{\Y_n... \given \x_n...}}{\pof{\Y_n... \given \x_n...}} \quad \forall n \\
+&\quad \ge \Hof{\Dany}.
+\end{aligned}
+$$
+
+This objective differs from the standard variational inference objective in a subtle but crucial way: it operates in the space of equivalence classes $$[\w]$$ rather than the raw parameter space $$\w$$. The likelihood term $$\pof{\Dany \given [\w]}$$ is well-defined because all parameters $$\w$$ within an equivalence class $$[\w]$$ induce the same likelihood by construction, allowing us to replace it with the likelihood term $$\pof{\Dany \given \w}$$.
+
+The key insight is that FSVI leverages the data processing inequality (DPI) to avoid explicitly constructing the equivalence classes for the prior distribution or specifying a model that operates on them directly. 
+By matching the predictive distributions via the predictive KL term, FSVI implicitly matches the priors over equivalence classes in the limit of infinite data, as shown in the previous section.
+
+This has advantages as overparameterized models are often simpler to optimize. The empirical evidence for this is the success of deep learning models, which are overparameterized and trained with stochastic gradient descent. 
+
+This highlights the elegance and conceptual clarity of FSVI:
+
+<aside class="l-body box-important" markdown="1">
+FSVI is a principled approach to Bayesian inference that respects the inherent symmetries and equivalences in overparameterized models. It focuses on approximating the meaningful posterior $$\pof{[\w] \given \Dany}$$ while avoiding the complexities of explicitly constructing and working with equivalence classes.
+</aside>
+
+## Parameter Priors vs. Predictive Priors
 
 In Bayesian deep learning, we often use parameter priors that are not meaningful and which also do not take parameter symmetries into account. For example, a unit Gaussian prior over the parameters of a neural network does not induce different predictions for different parameters necessarily. While this prior can be sensible from a parameter compression perspective (e.g. see Hinton and van Camp (1993)<d-cite key="hinton1993keeping"></d-cite>), this does not have to be the only consideration guiding us.
 

--- a/assets/bibliography/2024-05-07-dpi-fsvi.bib
+++ b/assets/bibliography/2024-05-07-dpi-fsvi.bib
@@ -1,5 +1,5 @@
 @article{sun2019functional,
-  title     = "Functional variational Bayesian neural networks",
+  title     = "Functional Variational Bayesian Neural Networks",
   author    = "Shengyang Sun and Guodong Zhang and Jiaxin Shi and Roger Grosse",
   booktitle = "International Conference on Learning Representations",
   year      = "2019",
@@ -7,7 +7,7 @@
 }
 
 @inproceedings{klarner2023drug,
-  title        = "Drug discovery under covariate shift with domain-informed prior distributions over functions",
+  title        = "Drug Discovery under Covariate Shift with Domain-Informed Prior Distributions over Functions",
   author       = "Klarner, Leo and Rudner, Tim GJ and Reutlinger, Michael and Schindler, Torsten and Morris, Garrett M and Deane, Charlotte and Teh, Yee Whye",
   booktitle    = "International Conference on Machine Learning",
   pages        = "17176--17197",
@@ -28,7 +28,7 @@
 
 
 @inproceedings{osband2022evaluating,
-  title     = "Evaluating high-order predictive distributions in deep learning",
+  title     = "Evaluating High-Order Predictive Distributions in Deep Learning",
   author    = "Osband, Ian and Wen, Zheng and Asghari, Seyed Mohammad and Dwaracherla, Vikranth and Lu, Xiuyuan and Van Roy, Benjamin",
   booktitle = "Proceedings of the Thirty-Eighth Conference on Uncertainty in Artificial Intelligence",
   pages     = "1552--1560",
@@ -40,11 +40,10 @@
   publisher = "PMLR",
   pdf       = "https://proceedings.mlr.press/v180/osband22a/osband22a.pdf",
   url       = "https://proceedings.mlr.press/v180/osband22a.html",
-  abstract  = "Most work on supervised learning research has focused on marginal predictions. In decision problems, joint predictive distributions are essential for good performance. Previous work has developed methods for assessing low-order predictive distributions with inputs sampled i.i.d. from the testing distribution. With low-dimensional inputs, these methods distinguish agents that effectively estimate uncertainty from those that do not. We establish that the predictive distribution order required for such differentiation increases greatly with input dimension, rendering these methods impractical. To accommodate high-dimensional inputs, we introduce dyadic sampling, which focuses on predictive distributions associated with random pairs of inputs. We demonstrate that this approach efficiently distinguishes agents in high-dimensional examples involving simple logistic regression as well as complex synthetic and empirical data."
 }
 
 @inproceedings{wang2021beyond,
-  title     = " Beyond Marginal Uncertainty: How Accurately can Bayesian Regression Models Estimate Posterior Predictive Correlations? ",
+  title     = "Beyond Marginal Uncertainty: How Accurately can Bayesian Regression Models Estimate Posterior Predictive Correlations?",
   author    = "Wang, Chaoqi and Sun, Shengyang and Grosse, Roger",
   booktitle = "Proceedings of The 24th International Conference on Artificial Intelligence and Statistics",
   pages     = "2476--2484",
@@ -56,7 +55,6 @@
   publisher = "PMLR",
   pdf       = "http://proceedings.mlr.press/v130/wang21g/wang21g.pdf",
   url       = "https://proceedings.mlr.press/v130/wang21g.html",
-  abstract  = " While uncertainty estimation is a well-studied topic in deep learning, most such work focuses on marginal uncertainty estimates, i.e. the predictive mean and variance at individual input locations. But it is often more useful to estimate predictive correlations between the function values at different input locations. In this paper, we consider the problem of benchmarking how accurately Bayesian models can estimate predictive correlations. We first consider a downstream task which depends on posterior predictive correlations: transductive active learning (TAL). We find that TAL makes better use of models’ uncertainty estimates than ordinary active learning, and recommend this as a benchmark for evaluating Bayesian models. Since TAL is too expensive and indirect to guide development of algorithms, we introduce two metrics which more directly evaluate the predictive correlations and which can be computed efficiently: meta-correlations (i.e. the correlations between the models correlation estimates and the true values), and cross-normalized likelihoods (XLL). We validate these metrics by demonstrating their consistency with TAL performance and obtain insights about the relative performance of current Bayesian neural net and Gaussian process models. "
 }
 
 @inproceedings{rudner2022tractable,
@@ -65,7 +63,8 @@
   booktitle = "Advances in Neural Information Processing Systems",
   editor    = "Alice H. Oh and Alekh Agarwal and Danielle Belgrave and Kyunghyun Cho",
   year      = "2022",
-  url       = "https://openreview.net/forum?id=OQs0pLKGGpS"
+  pdf       = "https://arxiv.org/pdf/2312.17199.pdf",
+  url       = "https://arxiv.org/abs/2312.17199"
 }
 
 
@@ -80,9 +79,8 @@
   series    = "Proceedings of Machine Learning Research",
   month     = "17--23 Jul",
   publisher = "PMLR",
-  pdf       = "https://proceedings.mlr.press/v162/rudner22a/rudner22a.pdf",
-  url       = "https://proceedings.mlr.press/v162/rudner22a.html",
-  abstract  = "Sequential Bayesian inference over predictive functions is a natural framework for continual learning from streams of data. However, applying it to neural networks has proved challenging in practice. Addressing the drawbacks of existing techniques, we propose an optimization objective derived by formulating continual learning as sequential function-space variational inference. In contrast to existing methods that regularize neural network parameters directly, this objective allows parameters to vary widely during training, enabling better adaptation to new tasks. Compared to objectives that directly regularize neural network predictions, the proposed objective allows for more flexible variational distributions and more effective regularization. We demonstrate that, across a range of task sequences, neural networks trained via sequential function-space variational inference achieve better predictive accuracy than networks trained with related methods while depending less on maintaining a set of representative points from previous tasks."
+  pdf       = "https://arxiv.org/pdf/2312.17210.pdf",
+  url       = "https://arxiv.org/abs/2312.17210",
 }
 
 @inproceedings{burt2021understanding,
@@ -94,22 +92,24 @@
 }
 
 @article{hinton2015distilling,
-  title   = "Distilling the knowledge in a neural network",
+  title   = "Distilling the Knowledge in a Neural Network",
   author  = "Hinton, Geoffrey and Vinyals, Oriol and Dean, Jeff",
   journal = "arXiv preprint arXiv:1503.02531",
-  year    = "2015"
+  year    = "2015",
+  pdf     = "https://arxiv.org/pdf/1503.02531.pdf",
+  url     = "https://arxiv.org/abs/1503.02531"
 }
 
 @inproceedings{hinton1993keeping,
-  title     = "Keeping the neural networks simple by minimizing the description length of the weights",
+  title     = "Keeping the Neural Network Simple by Minimizing the Description Length of the Weights",
   author    = "Hinton, Geoffrey E and Van Camp, Drew",
-  booktitle = "Proceedings of the sixth annual conference on Computational learning theory",
+  booktitle = "Proceedings of the Sixth Annual Conference on Computational Learning Theory",
   pages     = "5--13",
   year      = "1993"
 }
 
 @article{fortuin2022priors,
-  title     = "Priors in bayesian deep learning: A review",
+  title     = "Priors in Bayesian Deep Learning: A Review",
   author    = "Fortuin, Vincent",
   journal   = "International Statistical Review",
   volume    = "90",
@@ -131,14 +131,18 @@
   title   = "Marginal and Joint Cross-Entropies & Predictives for Online Bayesian Inference, Active Learning, and Active Sampling",
   author  = "Kirsch, Andreas and Kossen, Jannik and Gal, Yarin",
   journal = "arXiv preprint arXiv:2205.08766",
-  year    = "2022"
+  year    = "2022",
+  pdf     = "https://arxiv.org/pdf/2205.08766.pdf",
+  url     = "https://arxiv.org/abs/2205.08766"
 }
 
 @misc{fort2020deep,
-      title={Deep Ensembles: A Loss Landscape Perspective}, 
-      author={Stanislav Fort and Huiyi Hu and Balaji Lakshminarayanan},
-      year={2020},
-      eprint={1912.02757},
-      archivePrefix={arXiv},
-      primaryClass={stat.ML}
+  title={Deep Ensembles: A Loss Landscape Perspective}, 
+  author={Stanislav Fort and Huiyi Hu and Balaji Lakshminarayanan},
+  year={2020},
+  eprint={1912.02757},
+  archivePrefix={arXiv},
+  primaryClass={stat.ML},
+  url={https://arxiv.org/abs/1912.02757},
+  pdf={https://arxiv.org/pdf/1912.02757.pdf}
 }


### PR DESCRIPTION
Added a sub-section to show that the "true" FSVI objective using the equivalence class formulation is principled VI towards the posterior distribution of equivalence classes.

Updated abstract, introduction, and conclusion accordingly.

This contribution was there between the lines but not sufficiently explicit, which I have realized after discussing with Tim Rudner.